### PR TITLE
added clearViewingHistory(movieID,seriesAll,callback) addressing issue #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ netflix.login(credentials, callback)
 ```
 
 ### Browse
+Browse movies: pass the genre (id), which page number (if more are available) and how many iterms per page to display along with the callback for the result.
 ```javascript
 /**
  * Browse movies, to simply get all films use Category ID 34399
@@ -46,11 +47,10 @@ netflix.login(credentials, callback)
 netflix.browse(genreId, page, perPage, function (error, result) {
   if(error){
     console.error(error);
-  }else{
+  } else {
     console.log(JSON.stringify(result));
   }
 })
-
 ``` 
 
 ### Get Profiles
@@ -83,16 +83,19 @@ netflix.getRatingHistory(function (error, ratings) {
 
 ### Get Viewing History
 ```javascript
-netflix.getViewingHistory(function (error, viewing) {
-  ratings === [
-    {"title":"Futurama","movieID":70153380,"yourRating":4.0, ...},
-    {"title":"Super Troopers","movieID":60022689,"yourRating":4.0, ...},
-    ...
-  ]
+netflix.getViewingHistory(function (error, result) {
+  if(error){
+    console.error(error);
+  } else {
+    console.log(JSON.stringify(result));
+  }
 })
 ```
 
 ### Hide Viewing History for a movie/series
+
+Hide the viewing activity with the option of clearing the whole series or not.
+
 ```javascript
 /**
  * Hides viewing history for a specific movie or series
@@ -102,12 +105,16 @@ netflix.getViewingHistory(function (error, viewing) {
 netflix.hideMovieViewingHistory(movieID, hideAllSeries, function (error, result){
   if(error){
     console.error(error);
-  }else{
+  } else {
     console.log(JSON.stringify(result));
   }
 })
 ```
 ### Hide Viewing History for everything
+
+Hide the complete viewing history.
+**Note:** this may not always reset the viewing history per series
+
 ```javascript
 /**
  * Hides ALL viewing history: this may not always reset the viewing history per series (**no UNDO!**)
@@ -117,7 +124,7 @@ netflix.hideMovieViewingHistory(movieID, hideAllSeries, function (error, result)
  netflix.hideAllViewingHistory(function (error, result){
   if(error){
     console.error(error);
-  }else{
+  } else {
     console.log(JSON.stringify(result));
   }
 })
@@ -136,7 +143,7 @@ netflix.setThumbRating(movieID, rating, callback)
 netflix.getActiveProfile(function (error, result){
   if(error){
     console.error(error);
-  }else{
+  } else {
     console.log(JSON.stringify(result));
   }
 })

--- a/README.md
+++ b/README.md
@@ -3,29 +3,29 @@
 A client library to access the not-so-public Netflix Shakti API.
 
 ## Installation
-```
+```bash
 npm install netflix2
 ```
 
 ## Usage
 All functions take standard Node callbacks:
-```
+```javascript
 function callback (error, result) {}
 ```
 
 ### Initialization
-```
+```javascript
 var Netflix = require('netflix2')
 var netflix = new Netflix()
 ```
 or
-```
+```javascript
 var netflix = require('netflix2')()
 ```
 
 ### Login
 You must call `login` before using any of the other below functions. This will set cookies, API endpoints, and the authURL that must used to make API calls.
-```
+```javascript
 var credentials = {
   email: 'youremail@example.com'
   password: 'yourpassword'
@@ -33,8 +33,28 @@ var credentials = {
 netflix.login(credentials, callback)
 ```
 
+### Browse
+```javascript
+/**
+ * Browse movies, to simply get all films use Category ID 34399
+ *
+ * @param genreId The Netflix Category ID, Like https://www.netflix.com/browse/genre/34399
+ * @param page The content is paged, this is the page number.
+ * @param perPage How many items do you want per page?
+ * @param callback Function to be called when the request is finished.
+ */
+netflix.browse(genreId, page, perPage, function (error, result) {
+  if(error){
+    console.error(error);
+  }else{
+    console.log(JSON.stringify(result));
+  }
+})
+
+``` 
+
 ### Get Profiles
-```
+```javascript
 netflix.getProfiles(function (error, profiles) {
   profiles === [
     {"firstName":"Lana", "guid":"BLRHT3T5WVF5TLL6VDX2Z2NA2E", ...},
@@ -46,12 +66,12 @@ netflix.getProfiles(function (error, profiles) {
 
 ### Switch Profile
 Functions like `getRatingHistory` and `getRatingHistory` operate in the context of the current profile. Use `switchProfile` to change the current profile. Find the profile GUID using `getProfiles` above.
-```
+```javascript
 netflix.switchProfile(guid, callback)
 ```
 
 ### Get Rating History
-```
+```javascript
 netflix.getRatingHistory(function (error, ratings) {
   ratings === [
     {"title":"Futurama","movieID":70153380,"yourRating":4.0, ...},
@@ -61,12 +81,75 @@ netflix.getRatingHistory(function (error, ratings) {
 })
 ```
 
+### Get Viewing History
+```javascript
+netflix.getViewingHistory(function (error, viewing) {
+  ratings === [
+    {"title":"Futurama","movieID":70153380,"yourRating":4.0, ...},
+    {"title":"Super Troopers","movieID":60022689,"yourRating":4.0, ...},
+    ...
+  ]
+})
+```
+
+### Hide Viewing History for a movie/series
+```javascript
+/**
+ * Hides viewing history for a specific movie or series
+ * @param movieID  - the ID of the movie (e.g. 80057281 for "Stranger Things")
+ * @param seriesAll - true if you want to clear the whole series, false otherwise
+ */
+netflix.hideMovieViewingHistory(movieID, hideAllSeries, function (error, result){
+  if(error){
+    console.error(error);
+  }else{
+    console.log(JSON.stringify(result));
+  }
+})
+```
+### Hide Viewing History for everything
+```javascript
+/**
+ * Hides ALL viewing history: this may not always reset the viewing history per series (**no UNDO!**)
+ * use hideMovieViewingHistory passing the movieID and setting seriesAll to true
+ * to reset that series' history back to the first episode
+ */
+ netflix.hideAllViewingHistory(function (error, result){
+  if(error){
+    console.error(error);
+  }else{
+    console.log(JSON.stringify(result));
+  }
+})
+```
+
 ### Set Video Rating
 On Netflix, users used to rate videos with stars. Then Netflix switched over to thumbs and now some users don't even 
 know about the stars. You can set both types of ratings by using these two functions:
-```
+```javascript
 netflix.setStarRating(movieID, rating, callback)
 netflix.setThumbRating(movieID, rating, callback)
+```
+
+### Get Active Profile
+```javascript
+netflix.getActiveProfile(function (error, result){
+  if(error){
+    console.error(error);
+  }else{
+    console.log(JSON.stringify(result));
+  }
+})
+```
+
+### Get Avatar URL
+```javascript
+console.log(netflix.getAvatarUrl(avatarName, size));
+```
+
+### Set Avatar Name
+```javascript
+netflix.setAvatar(avatarName, callback);
 ```
 
 ## Warning

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -206,19 +206,45 @@ Netflix.prototype.__getViewingHistory = function (page, callback) {
 }
 
 /**
- * Clears viewhing history for a specific movie or series
+ * Hides viewing history for a specific movie or series
  * @param movieID  - the ID of the movie (e.g. 80057281 for "Stranger Things")
  * @param seriesAll - true if you want to clear the whole series, false otherwise
  */
-Netflix.prototype.clearViewingHistory = function (movieID, seriesAll, callback) {
+Netflix.prototype.hideMovieViewingHistory = function (movieID, seriesAll, callback) {
   this.__clearViewingHistory(movieID, seriesAll, callback);
 }
 
-Netflix.prototype.__clearViewingHistory = function (movieID, seriesAll, callback) {
+Netflix.prototype.__hideMovieViewingHistory = function (movieID, seriesAll, callback) {
   var options = {
     body: {
       movieID: movieID,
       seriesAll: seriesAll,
+      authURL: this.authUrls[constants.yourAccountUrl]
+    },
+    method: 'POST'
+  }
+  var endpoint = constants.viewingActivity
+  this.__apiRequest(endpoint, options, function (error, response, json) {
+    if (error) {
+      return callback(error)
+    }
+    callback(null, json)
+  })
+}
+
+/**
+ * Hides ALL viewing history: this may not always reset the viewing history per series
+ * use hideMovieViewingHistory passing the movieID and setting seriesAll to true
+ * to reset that series' history back to the first episode
+ */
+Netflix.prototype.hideAllViewingHistory = function (callback) {
+  this.__hideAllViewingHistory(callback);
+}
+
+Netflix.prototype.__hideAllViewingHistory = function (callback) {
+  var options = {
+    body: {
+      hideAll: true,
       authURL: this.authUrls[constants.yourAccountUrl]
     },
     method: 'POST'

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -233,8 +233,8 @@ Netflix.prototype.__hideMovieViewingHistory = function (movieID, seriesAll, call
 }
 
 /**
- * Hides ALL viewing history: this may not always reset the viewing history per series
- * use hideMovieViewingHistory passing the movieID and setting seriesAll to true
+ * Hides ALL viewing history: this may not always reset the viewing history per series.
+ * Use hideMovieViewingHistory passing the movieID and setting seriesAll to true
  * to reset that series' history back to the first episode
  */
 Netflix.prototype.hideAllViewingHistory = function (callback) {

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -206,15 +206,21 @@ Netflix.prototype.__getViewingHistory = function (page, callback) {
 }
 
 /**
- * Hides viewing history for a specific movie or series
+ * Hides viewing history for a specific movie or episode
  * @param movieID  - the ID of the movie (e.g. 80057281 for "Stranger Things")
- * @param seriesAll - true if you want to clear the whole series, false otherwise
  */
-Netflix.prototype.hideMovieViewingHistory = function (movieID, seriesAll, callback) {
-  this.__hideMovieViewingHistory(movieID, seriesAll, callback);
+Netflix.prototype.hideSingleEpisodeFromViewingActivity = function (movieID, callback) {
+  this.__hideSpecificViewingHistory(movieID, false, callback);
+}
+/**
+ * Hides viewing history for a the whole series with the supplied movieID
+ * @param movieID  - the ID of the movie (e.g. 80057281 for "Stranger Things")
+ */
+Netflix.prototype.hideEntireSeriesFromViewingHistory = function (movieID, callback) {
+  this.__hideSpecificViewingHistory(movieID, true, callback);
 }
 
-Netflix.prototype.__hideMovieViewingHistory = function (movieID, seriesAll, callback) {
+Netflix.prototype.__hideSpecificViewingHistory = function (movieID, seriesAll, callback) {
   var options = {
     body: {
       movieID: movieID,

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -205,6 +205,33 @@ Netflix.prototype.__getViewingHistory = function (page, callback) {
   })
 }
 
+/**
+ * Clears viewhing history for a specific movie or series
+ * @param movieID  - the ID of the movie (e.g. 80057281 for "Stranger Things")
+ * @param seriesAll - true if you want to clear the whole series, false otherwise
+ */
+Netflix.prototype.clearViewingHistory = function (movieID, seriesAll, callback) {
+  this.__clearViewingHistory(movieID, seriesAll, callback);
+}
+
+Netflix.prototype.__clearViewingHistory = function (movieID, seriesAll, callback) {
+  var options = {
+    body: {
+      movieID: movieID,
+      seriesAll: seriesAll,
+      authURL: this.authUrls[constants.yourAccountUrl]
+    },
+    method: 'POST'
+  }
+  var endpoint = constants.viewingActivity
+  this.__apiRequest(endpoint, options, function (error, response, json) {
+    if (error) {
+      return callback(error)
+    }
+    callback(null, json)
+  })
+}
+
 Netflix.prototype.__setRating = function (isThumbRating, titleId, rating, callback) {
   var endpoint = isThumbRating ? constants.setThumbRatingEndpointUrl : constants.setVideoRatindEndpointUrl
   var options = {

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -211,7 +211,7 @@ Netflix.prototype.__getViewingHistory = function (page, callback) {
  * @param seriesAll - true if you want to clear the whole series, false otherwise
  */
 Netflix.prototype.hideMovieViewingHistory = function (movieID, seriesAll, callback) {
-  this.__clearViewingHistory(movieID, seriesAll, callback);
+  this.__hideMovieViewingHistory(movieID, seriesAll, callback);
 }
 
 Netflix.prototype.__hideMovieViewingHistory = function (movieID, seriesAll, callback) {


### PR DESCRIPTION
Issue #14 mentions both adding and removing from a user's watching.

This pull request simply removes an item from `/viewingactivity` and the whole series if that's required.

Example usage: clear the whole series of "Stranger Things" from the viewing history (assuming login has completed):

```javascript
netflix.clearViewingHistory(80057281, true, (error, result) => {

	if(error) {
		console.error(error);
	}else{
		console.log(JSON.stringify(result));
	}
	
});
```
This is the equivalent of selecting **"Hide from viewing history" (⊘)** then **"Hide series?"** from [/viewingactivity](https://www.netflix.com/viewingactivity).

This pull request does **not** support adding anything to the watching