### PR TITLE
Make shakti API base URL constant

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -390,6 +390,7 @@ Netflix.prototype.__getContextData = function (url, callback) {
         }
       }
     })
+    const shaktiApiRootUrl = 'https://www.netflix.com/api/shakti/'
     /*
      * For some reason, context.netflix.reactContext does not always exist. The cause may be wether an account is active
      * or not, but that is not for sure.
@@ -399,12 +400,12 @@ Netflix.prototype.__getContextData = function (url, callback) {
      */
     if (context.netflix.reactContext) {
       self.netflixContext = context.netflix.reactContext.models
-      self.apiRoot = self.netflixContext.serverDefs.data.SHAKTI_API_ROOT + '/' + self.netflixContext.serverDefs.data.BUILD_IDENTIFIER
+      self.apiRoot = shaktiApiRootUrl + self.netflixContext.serverDefs.data.BUILD_IDENTIFIER
       self.endpointIdentifiers = self.netflixContext.serverDefs.data.endpointIdentifiers
       self.authUrls[url] = context.netflix.reactContext.models.memberContext.data.userInfo.authURL
     } else if (context.netflix.contextData) {
       self.netflixContext = context.netflix.contextData
-      self.apiRoot = 'https://www.netflix.com/api/shakti/' + context.netflix.contextData.serverDefs.BUILD_IDENTIFIER
+      self.apiRoot = shaktiApiRootUrl + context.netflix.contextData.serverDefs.BUILD_IDENTIFIER
       self.endpointIdentifiers = {}
       // TODO: The auth URL is probably somewhere else. Figure out where it is exactly when a user logs into an inactive
       // account.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -941,9 +941,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A client library to access the not-so-public Netflix Shakti API.",
   "keywords": [
     "netflix",


### PR DESCRIPTION
Apparently, Netflix changed their data structures again and removed the base URL to their shakti API. The URL still exists, it just isn't stored in the same objects as it used to be.

This PR stops retrieving that URL dynamically and uses it as a constant. This should be undone as soon as the URL is found somewhere in those objects!