### PR TITLE
Fix 500 Internal Error in setRating

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -267,15 +267,16 @@ Netflix.prototype.__hideAllViewingHistory = function (callback) {
 Netflix.prototype.__setRating = function (isThumbRating, titleId, rating, callback) {
   var endpoint = isThumbRating ? constants.setThumbRatingEndpointUrl : constants.setVideoRatindEndpointUrl
   var options = {
-    qs: {
+    body: {
       rating: rating,
       authURL: this.authUrls[constants.yourAccountUrl]
-    }
+    },
+    method: 'POST'
   }
   if (isThumbRating) {
-    options.qs.titleId = titleId
+    options.body.titleId = titleId
   } else {
-    options.qs.titleid = titleId
+    options.body.titleid = titleId
   }
   this.__apiRequest(endpoint, options, function (error, response, json) {
     if (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
     "acorn": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "optional": true
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -325,7 +326,8 @@
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -1043,9 +1045,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "mime-db": {
       "version": "1.38.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A client library to access the not-so-public Netflix Shakti API.",
   "keywords": [
     "netflix",


### PR DESCRIPTION
The rating data used to be sent to Netflix as a query string (such as `https://www.netflix.com/someUrl?key=value&foo=bar`) and this did not set the `content-type: application/json` header. Netflix didn't use to have a problem with that, but apparently it now causes a 500 Internal Error now.

The solution was to pass the data in the requests body (the method must be set to `POST` to transmit a body!) because then the option `json: true` (which was already set) sets said header.

Other methods might still have the same problem (which might cause mire errors with Netflix's API in the future).

This provides the solution for https://github.com/LBBO/netflix-migrate/issues/38