### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ netflix.login(credentials, callback)
 ```
 
 ### Browse
-Browse movies: pass the genre (id), which page number (if more are available) and how many iterms per page to display along with the callback for the result.
+Browse movies: pass the genre (id), which page number (if more are available) and how many items per page to display along with the callback for the result.
 ```javascript
 /**
  * Browse movies, to simply get all films use Category ID 34399


### PR DESCRIPTION
Hi! I noticed this typo while I was reading the readme. I'm guessing it's meant to be items, not [iTerms](https://www.iterm2.com/) 😉 