### PR TITLE
Check correct credentials

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -458,9 +458,9 @@ Netflix.prototype.__getContextData = function (url, callback) {
      * Currently, this fixes the issue, as the shakti API root seems to always be identical and endpointIdentifiers
      * seem to always be an empty object. This is a quick and dirty fix due to lack of more information!
      */
-    if (context.netflix.reactContext.models.memberContext == undefined) {
+    if (context.netflix.reactContext.models.memberContext === undefined && context.netflix.contextData.authURL === undefined) {
       throw new Error(
-        'The specified Login are incorrect. Please check the username or password.'
+        'The specified Login are incorrect, please check the username or password.'
       )
     } else if (context.netflix.reactContext) {
       self.netflixContext = context.netflix.reactContext.models

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -458,7 +458,11 @@ Netflix.prototype.__getContextData = function (url, callback) {
      * Currently, this fixes the issue, as the shakti API root seems to always be identical and endpointIdentifiers
      * seem to always be an empty object. This is a quick and dirty fix due to lack of more information!
      */
-    if (context.netflix.reactContext) {
+    if (context.netflix.reactContext.models.memberContext == undefined) {
+      throw new Error(
+        'The specified Login are incorrect. Please check the username or password.'
+      )
+    } else if (context.netflix.reactContext) {
       self.netflixContext = context.netflix.reactContext.models
       self.apiRoot = shaktiApiRootUrl + self.netflixContext.serverDefs.data.BUILD_IDENTIFIER
       self.endpointIdentifiers = self.netflixContext.serverDefs.data.endpointIdentifiers


### PR DESCRIPTION
Add the capability to check if the specified account have entered the correct credentials, to stop the error of: TypeError: Cannot read property 'data' of undefined