### PR TITLE
Change async waterfall to use error callback

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -50,7 +50,9 @@ Netflix.prototype.login = function (credentials, callback) {
       async.constant(credentials),
       self.__getLoginForm.bind(self),
       self.__postLoginForm.bind(self)
-    ], getContextData)
+      self.__getContextData.bind(self, constants.yourAccountUrl),
+      self.__getContextData.bind(self, constants.manageProfilesUrl)
+    ], callback)
   } else {
     getContextData()
   }


### PR DESCRIPTION
Fixes #20. Error was getting discarded in the callback to `getContextData()` call.